### PR TITLE
Add the option to switch between checkouts for development

### DIFF
--- a/Plugin/PickRandomCheckout.php
+++ b/Plugin/PickRandomCheckout.php
@@ -7,6 +7,7 @@ use Hyva\Checkout\Model\CheckoutInformation\Luma;
 use Hyva\Checkout\Model\Config;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\RequestInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Serialize\SerializerInterface;
@@ -20,7 +21,8 @@ class PickRandomCheckout
         private readonly CheckoutSession $checkoutSession,
         private readonly State $appState,
         private readonly ScopeConfigInterface $config,
-        private readonly SerializerInterface $serializer
+        private readonly SerializerInterface $serializer,
+        private readonly RequestInterface $request,
     ) {
 
     }
@@ -54,6 +56,10 @@ class PickRandomCheckout
 
         // When in developer mode, use the default configuration
         if ($this->appState->getMode() === State::MODE_DEVELOPER) {
+            if ($this->request->getParam('active_checkout_namespace')) {
+                return $this->request->getParam('active_checkout_namespace');
+            }
+
             return $result;
         }
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ You can enable the extension under Stores > Configuration > Hyvä Themes > Check
 
 ![image](https://user-images.githubusercontent.com/431360/201086503-6c54b1e0-68bd-4ec2-ab6b-e85bb52854b5.png)
 
+## Usage
+
+The module will switch the checkout first by using the randomizer selecting between the options that are configured.
+
+If your magento instaltion is in development mode you it will allways select the default set checkout set in `hyva_themes_checkout/general/checkout`.
+When you then add the query parameter `active_checkout_namespace` in the url you can switch manually between checkouts.
+So for instance you can use `http://store.test/checkout?active_checkout_namespace=hyva`.
+
 ## Reports
 
 You can check the progress of the A/B test by running this query;


### PR DESCRIPTION
For development it is of-course nice that it switches to the default checkout per standard.

But since you also have to test changes between multiple checkouts if make impact-full changes it is nice to be able to easily switch between those.