### PR TITLE
Add store config to use url overwrite on production

### DIFF
--- a/Plugin/PickRandomCheckout.php
+++ b/Plugin/PickRandomCheckout.php
@@ -55,15 +55,20 @@ class PickRandomCheckout
             return $result;
         }
 
-        // Check if URL parameter override is explicitly enabled in config (highest priority)
-        if ($this->config->getValue(self::HYVA_CHECKOUT_AB_TEST_ALLOW_URL_PARAM_OVERRIDE, ScopeInterface::SCOPE_STORE)) {
+        // Check if URL parameter override is allowed:
+        // - Always in developer mode
+        // - In production only if explicitly enabled in config
+        $allowUrlParamOverride = ($this->appState->getMode() === State::MODE_DEVELOPER)
+            || $this->config->getValue(self::HYVA_CHECKOUT_AB_TEST_ALLOW_URL_PARAM_OVERRIDE, ScopeInterface::SCOPE_STORE);
+
+        if ($allowUrlParamOverride) {
             $paramCheckout = $this->request->getParam('active_checkout_namespace');
             if ($paramCheckout && $this->isValidCheckout($paramCheckout, $checkouts)) {
                 return $paramCheckout;
             }
         }
 
-        // When in developer mode, use the default configuration
+        // When in developer mode and no valid URL parameter was provided, use the default configuration
         if ($this->appState->getMode() === State::MODE_DEVELOPER) {
             return $result;
         }

--- a/README.md
+++ b/README.md
@@ -19,11 +19,30 @@ You can enable the extension under Stores > Configuration > Hyvä Themes > Check
 
 ## Usage
 
-The module will switch the checkout first by using the randomizer selecting between the options that are configured.
+### Checkout Selection
 
-If your magento instaltion is in development mode you it will allways select the default set checkout set in `hyva_themes_checkout/general/checkout`.
-When you then add the query parameter `active_checkout_namespace` in the url you can switch manually between checkouts.
-So for instance you can use `http://store.test/checkout?active_checkout_namespace=hyva`.
+The module determines which checkout to use based on the following priority:
+
+1. **URL Parameter Override** (if allowed)
+   - In **development mode**: The `active_checkout_namespace` URL parameter can always be used to manually select a checkout
+   - In **production mode**: The parameter can only be used if "Allow URL Parameter Override" is enabled in configuration
+
+2. **Developer Mode**: If no URL parameter is provided, development mode always uses the default checkout configured in `hyva_themes_checkout/general/checkout`
+
+3. **Random Assignment**: In production mode (without URL override), customers are randomly assigned to configured checkouts based on their percentage split
+
+### Manual Checkout Selection via URL
+
+You can manually override the checkout selection by adding the `active_checkout_namespace` query parameter:
+
+```
+http://store.test/checkout?active_checkout_namespace=hyva
+http://store.test/checkout?active_checkout_namespace=luma
+```
+
+**In Development Mode:** This parameter always works and overrides the default checkout selection.
+
+**In Production Mode:** This parameter only works if "Allow URL Parameter Override" is enabled under Stores > Configuration > Hyvä Themes > Checkout > A/B Test.
 
 ## Reports
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,6 +19,11 @@
                     <frontend_model>Elgentos\HyvaCheckoutABTest\Block\Adminhtml\Form\Field\Checkouts</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                 </field>
+                <field id="allow_url_param_override" translate="label,comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Allow URL Parameter Override</label>
+                    <comment>When enabled, the active_checkout_namespace URL parameter can be used to override the A/B test selection on any environment</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
In order to use the url overwrite in production I made sure there is a validation on it before applying the overwrite.
I also made a store config so you can manage this.
And to keep it backwards compatible I made sure that this will still be posible in development mode.

This is documented in the readme.